### PR TITLE
Format and Samplerate conversion

### DIFF
--- a/ffmpeg_portaudio/src/audio_decoder.cpp
+++ b/ffmpeg_portaudio/src/audio_decoder.cpp
@@ -4,8 +4,6 @@
 #include <stdint.h>
 #include <iostream>
 
-#define RING_BUF_SIZE (1024*2*4)
-
 //TODO: stop stream after buffer has been emptied.
 
 audio_decoder::audio_decoder(av_data* ad, int deviceSampleRate) :

--- a/ffmpeg_portaudio/src/audio_decoder.h
+++ b/ffmpeg_portaudio/src/audio_decoder.h
@@ -17,8 +17,8 @@ extern "C"
 
 class audio_decoder
 {
-	std::ofstream myfile;
 	PaStream* stream;
+	av_data* m_ad;
 
 	void decode_thread(av_data* ad);
 
@@ -37,11 +37,14 @@ class audio_decoder
 
 	PaError init_port_audio(av_data* ad);
 	int select_portaudio_device();
-	void handle_error(PaError err);
-
 
 	static int pa_audio_callback(const void* inputBuffer, void* outputbuffer, unsigned long frameCount, const PaStreamCallbackTimeInfo* timeInfo, PaStreamCallbackFlags statusFlags, void* userData);
 
+	void handle_pa_error(PaError err);
+
+	void handle_av_error(int av_error);
+
 public:
 	audio_decoder(av_data* av);
+	~audio_decoder();
 };

--- a/ffmpeg_portaudio/src/audio_decoder.h
+++ b/ffmpeg_portaudio/src/audio_decoder.h
@@ -17,8 +17,10 @@ extern "C"
 
 class audio_decoder
 {
-	PaStream* stream;
 	av_data* m_ad;
+	int m_samplerate;
+	int m_bufferSize;
+	bool m_audioq_initialized = false;
 
 	void decode_thread(av_data* ad);
 
@@ -31,9 +33,9 @@ class audio_decoder
 	*/
 	int receive_frame(AVCodecContext* audio_ctx, AVFrame* audio_frame);
 
-	int convert_buffer(av_data* ad, AVFrame* audio_frame, uint8_t** dstBuffer);
+	int convert_buffer(av_data* ad, AVFrame* audio_frame, uint8_t*** dstBuffer);
 
-	int init_audio_q(av_data* ad);
+	int init_audio_q(av_data* ad, int nb_samples_all_ch, int frameCount);
 
 	PaError init_port_audio(av_data* ad);
 	int select_portaudio_device();
@@ -45,6 +47,9 @@ class audio_decoder
 	void handle_av_error(int av_error);
 
 public:
-	audio_decoder(av_data* av);
+	/*
+	deviceSampleRate: Samplerate to configure PortAudio to, and convert ffmpeg samples to.
+	*/
+	audio_decoder(av_data* av, int deviceSampleRate);
 	~audio_decoder();
 };

--- a/ffmpeg_portaudio/src/av_data.h
+++ b/ffmpeg_portaudio/src/av_data.h
@@ -13,4 +13,5 @@ struct av_data {
 	AVCodecContext* audio_ctx;
 	AVCodecContext* video_ctx;
 	PaUtilRingBuffer audio_buf;
+	struct SwrContext* audio_swr;
 };

--- a/ffmpeg_portaudio/src/ffmpeg_integration.cpp
+++ b/ffmpeg_portaudio/src/ffmpeg_integration.cpp
@@ -104,7 +104,7 @@ int ffmpeg_integration::open_stream_components(AVFormatContext* fmt_ctx, int str
 		ad->audio_streamID = stream_index;
 		ad->audio_ctx = codec_ctx;
 		PacketQueue::packet_queue_init(&ad->audio_q);
-		audio_dec = new audio_decoder(ad);
+		audio_dec = new audio_decoder(ad, 48000);
 		return 0;
 	case AVMEDIA_TYPE_VIDEO:
 		ad->video_streamID = stream_index;

--- a/ffmpeg_portaudio/src/ffmpeg_integration.cpp
+++ b/ffmpeg_portaudio/src/ffmpeg_integration.cpp
@@ -1,6 +1,8 @@
 #include "ffmpeg_integration.h"
 #include <iostream>
 
+#define DEBUG
+
 ffmpeg_integration::ffmpeg_integration(const char* filePath)
 {
 	ad = new av_data();

--- a/ffmpeg_portaudio/src/ffmpeg_portaudio.cpp
+++ b/ffmpeg_portaudio/src/ffmpeg_portaudio.cpp
@@ -1,5 +1,6 @@
 // ffmpeg_portaudio.cpp : This file contains the 'main' function. Program execution begins and ends there.
-//
+// "C:/Users/joach/Videos/test2.mp4"
+// "C:/Users/joach/OneDrive/Skrivebord/Arian.wav"
 
 #include <iostream>
 #include "ffmpeg_integration.h"


### PR DESCRIPTION
Implement format and sample-rate conversion, making the application work in 32-bit float internally at the specified samplerate, and resample with libswresample audio-files that dont conform to this.